### PR TITLE
UAR-783 - Proposal workflow customization [FE KCI-411]

### DIFF
--- a/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actions/ReturnToPreviousNodeAction.java
+++ b/rice-middleware/impl/src/main/java/org/kuali/rice/kew/actions/ReturnToPreviousNodeAction.java
@@ -15,6 +15,7 @@
  */
 package org.kuali.rice.kew.actions;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.log4j.Logger;
 import org.apache.log4j.MDC;
 import org.kuali.rice.kew.actionrequest.ActionRequestFactory;
@@ -42,6 +43,7 @@ import org.kuali.rice.kew.service.KEWServiceLocator;
 import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kim.api.identity.principal.Principal;
 import org.kuali.rice.kim.api.identity.principal.PrincipalContract;
+
 
 
 import java.util.ArrayList;
@@ -272,6 +274,16 @@ public class ReturnToPreviousNodeAction extends ActionTakenEvent {
         }
 
             Collection activeNodeInstances = KEWServiceLocator.getRouteNodeService().getActiveNodeInstances(getRouteHeader().getDocumentId());
+            
+            /* UAR-18 starts */
+            //There could be terminal node instances that may not get traced back correctly in certain cases
+            //those need to be included for generating the node graph
+            List<RouteNodeInstance> terminalNodeInstances = KEWServiceLocator.getRouteNodeService().getTerminalNodeInstances(getRouteHeader().getDocumentId());
+            if(CollectionUtils.isNotEmpty(terminalNodeInstances)) {
+            	activeNodeInstances.addAll(terminalNodeInstances);
+            }
+            /* UAR-18 ends */
+            
             NodeGraphSearchCriteria criteria = new NodeGraphSearchCriteria(NodeGraphSearchCriteria.SEARCH_DIRECTION_BACKWARD, activeNodeInstances, nodeName);
             NodeGraphSearchResult result = KEWServiceLocator.getRouteNodeService().searchNodeGraph(criteria);
             validateReturnPoint(nodeName, activeNodeInstances, result);


### PR DESCRIPTION
## In order to pull in all of the fixes for KC UAR-783, the following two changes were made:

UAR-284 Units dropping from workflow

Added RICE code from KC rice-1.0.3.3:
rice-middleware/impl/src/main/java/org/kuali/rice/kew/rule/FlexRM.java

Modified to contain FE fix, added logic to take into account hierarchy routing such that same level hierarchy route nodes are retained.

---

UAR-18, Superuser 'return' going to exception

Added RICE code from KC rice-1.0.3.3:
rice-middleware/impl/src/main/java/org/kuali/rice/kew/actions/ReturnToPreviousNodeAction.java

Modified to contain FE fix, added logic to ensure all route nodes are retained in this specific set of conditions.

---

IMPORTANT: This means local developers will need to build all 3 projects to get this jira's functionality. This also means there will be a pull request on the kc_custom_5.2.1 project. When deploying in our AWS instances, all three projects are built by default, so nothing needs to change there.
