### PR TITLE
UAR-990 - Superuser approve not working correctly, will also automatically approve next OSP stop (in some cases)

### DIFF
--- a/rice-middleware/kew/api/src/main/java/org/kuali/rice/kew/api/action/ActionType.java
+++ b/rice-middleware/kew/api/src/main/java/org/kuali/rice/kew/api/action/ActionType.java
@@ -208,7 +208,6 @@ public enum ActionType implements Coded {
      * @return super-user version of ActionType or null if no equivalent SU action type
      */
     public static ActionType toSuperUserActionType(ActionType at) {
-        if (SU_ACTION_TYPE.containsKey(at)) return at;
-        return SU_ACTION_TYPE.get(at);
+    	return SU_ACTION_TYPE.get(at);
     }
 }


### PR DESCRIPTION
The root cause of this was a code re-factor from rice v1 to v2 and how action type codes are processed. 

The solution was to change the ActionType class by removing one line that was nonsensical anyway, and botched the intended result. 

This change resulted in the correct action code being assigned to the action request record. The repercussions of which are: 
- The WorkflowEngine can now detect when a super user action has occurred in the graph 
-- The "Initial" node was marked as superuser approved 
-- Once the OSP node was up for processing, the engine knew not to superuser approve, since another node already was 