### PR TITLE
UAR-1192 Changed getMembers to getModifiedMembers because the members…

### DIFF
--- a/rice-middleware/kim/kim-ldap/src/main/java/org/kuali/rice/kim/service/impl/LdapUiDocumentServiceImpl.java
+++ b/rice-middleware/kim/kim-ldap/src/main/java/org/kuali/rice/kim/service/impl/LdapUiDocumentServiceImpl.java
@@ -402,21 +402,20 @@ public class LdapUiDocumentServiceImpl extends org.kuali.rice.kim.service.impl.U
         identityManagementRoleDocument.setKimType(KimApiServiceLocator.getKimTypeInfoService().getKimType(identityManagementRoleDocument.getRoleTypeId()));
         KimTypeService kimTypeService = KimFrameworkServiceLocator.getKimTypeService(identityManagementRoleDocument.getKimType());
 
-        if(CollectionUtils.isNotEmpty(identityManagementRoleDocument.getMembers())){
-            for(KimDocumentRoleMember documentRoleMember: identityManagementRoleDocument.getMembers()){
+        if(CollectionUtils.isNotEmpty(identityManagementRoleDocument.getModifiedMembers())){
+            for(KimDocumentRoleMember documentRoleMember: identityManagementRoleDocument.getModifiedMembers()){
                 origRoleMemberImplTemp = null;
 
                 newRoleMember = new RoleMemberBo();
                 KimCommonUtilsInternal.copyProperties(newRoleMember, documentRoleMember);
                 newRoleMember.setRoleId(identityManagementRoleDocument.getRoleId());
+                newRoleMember.setTypeCode(documentRoleMember.getMemberTypeCode());
                 if(ObjectUtils.isNotNull(origRoleMembers)){
                     for(RoleMemberBo origRoleMemberImpl: origRoleMembers){
                         if((origRoleMemberImpl.getRoleId()!=null && StringUtils.equals(origRoleMemberImpl.getRoleId(), newRoleMember.getRoleId())) &&
                             (origRoleMemberImpl.getMemberId()!=null && StringUtils.equals(origRoleMemberImpl.getMemberId(), newRoleMember.getMemberId())) &&
                             (origRoleMemberImpl.getType()!=null && org.apache.commons.lang.ObjectUtils.equals(origRoleMemberImpl.getType(), newRoleMember.getType())) &&
-                            !origRoleMemberImpl.isActive(new Timestamp(System.currentTimeMillis())) &&
-                            !kimTypeService.validateUniqueAttributes(identityManagementRoleDocument.getKimType().getId(),
-                                    documentRoleMember.getQualifierAsMap(), origRoleMemberImpl.getAttributes()).isEmpty()) {
+                            origRoleMemberImpl.isActive(new Timestamp(System.currentTimeMillis()))) {
 
                             //TODO: verify if you want to add  && newRoleMember.isActive() condition to if...
 


### PR DESCRIPTION
… variable in the IdentityManagementRoleDocument.java file is labeled with the @Transient annotation (meaning the variable should never be serialized, including into the database) and modifiedMembers is not. Next I changed some conditions of the if statement. I changed the check to see if the member is active instead of not active. This is necessary because in the case where the user wants to inactivate a role member, if an inactivated role member is found in the database, it will be updated instead of the active one therefore making it impossible to inactivate a role member. The check to validate unique attributes was removed because there is no check when saving a role to a person. Also, if validate unique attribute fails, then duplicate entries will be added to the database.